### PR TITLE
Explicitly calls URI.open

### DIFF
--- a/lib/fastlane/plugin/download_file/actions/download_file_action.rb
+++ b/lib/fastlane/plugin/download_file/actions/download_file_action.rb
@@ -17,8 +17,7 @@ module Fastlane
           partial = 0
           progress = 0
           File.open(destination_path, "wb") do |saved_file|
-            # the following "open" is provided by open-uri
-            open(params[:url], "rb", :content_length_proc => lambda {|t|
+            URI.open(params[:url], "rb", :content_length_proc => lambda {|t|
               if t && 0 < t
                 step = t / 10
                 partial = step


### PR DESCRIPTION
While Ruby 2.x allowed to override a Kernel call to open a file, this is not allowed in Ruby 3.x and an explicit call to `URI.open` needs to be made.

Tested with v2.7.6 and v.3.1.2